### PR TITLE
Rebase with upstream 2.16.0 release

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+- 2024-03-18
+    * Add bundle configuration for `login_method` for RabbitMQ connections, this allow to configure other values than default AMQPLAIN (PLAIN or EXTERNAL), see https://www.rabbitmq.com/docs/access-control#mechanisms
+
 - 2023-11-07
     * Add consumer option `no_ack`
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -3,6 +3,7 @@
 namespace OldSound\RabbitMqBundle\DependencyInjection;
 
 use OldSound\RabbitMqBundle\RabbitMq\Producer;
+use PhpAmqpLib\Connection\AMQPConnectionConfig;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
@@ -73,6 +74,14 @@ class Configuration implements ConfigurationInterface
                             ->scalarNode('user')->defaultValue('guest')->end()
                             ->scalarNode('password')->defaultValue('guest')->end()
                             ->scalarNode('vhost')->defaultValue('/')->end()
+                            ->enumNode('login_method')
+                                ->values([
+                                    AMQPConnectionConfig::AUTH_AMQPPLAIN,
+                                    AMQPConnectionConfig::AUTH_PLAIN,
+                                    AMQPConnectionConfig::AUTH_EXTERNAL,
+                                ])
+                                ->defaultValue(AMQPConnectionConfig::AUTH_AMQPPLAIN)
+                                ->end()
                             ->arrayNode('hosts')
                                 ->info('connection_timeout, read_write_timeout, use_socket, ssl_context, keepalive, 
                                         heartbeat and connection_parameters_provider should be specified globally when

--- a/README.md
+++ b/README.md
@@ -125,6 +125,9 @@ old_sound_rabbit_mq:
 
             #requires php_sockets.dll
             use_socket: true # default false
+            
+            login_method: 'AMQPLAIN' # default 'AMQPLAIN', can be 'EXTERNAL' or 'PLAIN', see https://www.rabbitmq.com/docs/access-control#mechanisms
+            
         another:
             # A different (unused) connection defined by an URL. One can omit all parts,
             # except the scheme (amqp:). If both segment in the URL and a key value (see above)

--- a/RabbitMq/Producer.php
+++ b/RabbitMq/Producer.php
@@ -91,7 +91,7 @@ class Producer extends BaseAmqp implements ProducerInterface
         $this->logger->debug('AMQP message published', [
             'amqp' => [
                 'body' => $msgBody,
-                'routingkeys' => $routingKey,
+                'routingkey' => $real_routingKey,
                 'properties' => $additionalProperties,
                 'headers' => $headers,
             ],

--- a/Tests/DependencyInjection/OldSoundRabbitMqExtensionTest.php
+++ b/Tests/DependencyInjection/OldSoundRabbitMqExtensionTest.php
@@ -40,6 +40,7 @@ class OldSoundRabbitMqExtensionTest extends TestCase
             'url' => '',
             'hosts' => [],
             'channel_rpc_timeout' => 0.0,
+            'login_method' => 'AMQPLAIN',
 
         ], $factory->getArgument(1));
         $this->assertEquals('%old_sound_rabbit_mq.connection.class%', $definition->getClass());
@@ -72,6 +73,7 @@ class OldSoundRabbitMqExtensionTest extends TestCase
             'url' => '',
             'hosts' => [],
             'channel_rpc_timeout' => 0.0,
+            'login_method' => 'AMQPLAIN',
         ], $factory->getArgument(1));
         $this->assertEquals('%old_sound_rabbit_mq.connection.class%', $definition->getClass());
     }
@@ -101,6 +103,7 @@ class OldSoundRabbitMqExtensionTest extends TestCase
             'url' => '',
             'hosts' => [],
             'channel_rpc_timeout' => 0.0,
+            'login_method' => 'AMQPLAIN',
         ], $factory->getArgument(1));
         $this->assertEquals('%old_sound_rabbit_mq.lazy.connection.class%', $definition->getClass());
     }
@@ -130,6 +133,7 @@ class OldSoundRabbitMqExtensionTest extends TestCase
             'url' => '',
             'hosts' => [],
             'channel_rpc_timeout' => 0.0,
+            'login_method' => 'AMQPLAIN',
         ], $factory->getArgument(1));
         $this->assertEquals('%old_sound_rabbit_mq.connection.class%', $definition->getClass());
     }
@@ -194,6 +198,7 @@ class OldSoundRabbitMqExtensionTest extends TestCase
             'use_socket' => false,
             'url' => '',
             'channel_rpc_timeout' => 0.0,
+            'login_method' => 'AMQPLAIN',
         ], $factory->getArgument(1));
         $this->assertEquals('%old_sound_rabbit_mq.connection.class%', $definition->getClass());
     }


### PR DESCRIPTION
This PR rebases us to the latest upstream release, 2.16.0. Needs testing.